### PR TITLE
レビュー指摘事項の修正

### DIFF
--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -75,6 +75,27 @@
           &:first-of-type {
             margin-bottom: 5px;
           }
+
+          > form {
+            display: inline;
+            margin: 0;
+            padding: 0;
+
+            > button {
+              background: none;
+              border: none;
+              cursor: pointer;
+              font-size: 14px;
+              line-height: 18px;
+              padding: 0;
+              text-align: left;
+              width: 100%;
+            }
+          }
+
+          &--danger > form > button {
+            color: #dc3545;
+          }
         }
       }
     }

--- a/app/assets/stylesheets/main/header.scss
+++ b/app/assets/stylesheets/main/header.scss
@@ -67,6 +67,23 @@
   min-width: 122px;
   padding: 9px 0;
 
+  &__delete-button {
+    background: none;
+    border: none;
+    color: $primary-red;
+    cursor: pointer;
+    display: block;
+    font-size: 14px;
+    line-height: 18px;
+    padding: 0;
+    text-align: left;
+    width: 100%;
+
+    &:hover {
+      background: none;
+    }
+  }
+
   &[data-bs-popper] {
     @include xs-device-or-less {
       left: -100% !important;
@@ -91,6 +108,29 @@
     &--danger {
       > a {
         color: $primary-red;
+      }
+
+      > form {
+        display: inline;
+        margin: 0;
+        padding: 0;
+
+        > button {
+          background: none;
+          border: none;
+          color: $primary-red;
+          cursor: pointer;
+          display: block;
+          font-size: 14px;
+          line-height: 18px;
+          padding: 0;
+          text-align: left;
+          width: 100%;
+
+          &:hover {
+            background: none;
+          }
+        }
       }
     }
   }

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -11,7 +11,21 @@ class Room < ApplicationRecord
     validates :price
   end
 
+  validates :name, length: { maximum: 255 }
   validates :price, numericality: { only_integer: true, greater_than: 0 }
+  validate :image_content_type_validation
+
+  private
+
+  def image_content_type_validation
+    return unless image.attached?
+
+    allowed_types = ['image/jpeg', 'image/png', 'image/gif']
+    unless allowed_types.include?(image.content_type)
+      errors.add(:image, :content_type_invalid)
+      image.purge
+    end
+  end
 
   scope :search_by_area, -> (area) {
     if area.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,17 @@ class User < ApplicationRecord
   has_many :reservations
 
   validates :name, presence: true
+  validate :image_content_type_validation
+
+  private
+
+  def image_content_type_validation
+    return unless image.attached?
+
+    allowed_types = ['image/jpeg', 'image/png', 'image/gif']
+    unless allowed_types.include?(image.content_type)
+      errors.add(:image, :content_type_invalid)
+      image.purge
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,16 +25,19 @@
     <%= javascript_include_tag 'application', 'data-turbo-track': 'reload', type: 'module' %>
 
     <script>
-      $(function(){
+      function initDatePicker() {
         $(".js-picker").bootstrapMaterialDatePicker({
           time: false,
-          weekStart :0,
+          weekStart: 0,
           switchOnClick: true,
           format: "YYYY/MM/DD",
           okText: "OK",
           clearText: "キャンセル"
-        })
-      })
+        });
+      }
+
+      $(document).ready(initDatePicker);
+      document.addEventListener("turbo:load", initDatePicker);
     </script>
   </head>
 

--- a/app/views/reservations/edit.html.erb
+++ b/app/views/reservations/edit.html.erb
@@ -26,7 +26,7 @@
       </p>
     </div>
 
-    <%= form_with model: @reservation, url: confirm_reservations_path, local: true, class: "Form ReservationsForm", method: :post do |f| %>
+    <%= form_with model: @reservation, url: confirm_reservations_path, local: true, data: { turbo: false }, class: "Form ReservationsForm", method: :post do |f| %>
       <%= hidden_field_tag "reservation[id]", @reservation.id %>
       <%= hidden_field_tag "reservation[room_id]", @reservation.room.id %>
 

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -61,24 +61,11 @@
                   </li>
 
                   <li class="DropdownMenu__item DropdownMenu__item--danger">
-                    <%= link_to "予約を削除",
-                                reservation,
+                    <%= button_to "予約を削除",
+                                reservation_path(reservation),
                                 method: :delete,
-                                title: "以下の施設を削除しますか？",
-                                data: {
-                                  confirm: "<div class='ConfirmBody'>
-                                              #{image_tag(room_image(reservation.room), class: 'ConfirmBody__image')}
-                                              <div>
-                                                #{reservation.room.name}<br>
-                                                #{reservation.start_date.strftime('%Y/%m/%d')}&nbsp;〜&nbsp;#{reservation.end_date.strftime('%Y/%m/%d')}<br>
-                                                #{reservation.person_num}人<br>
-                                                ¥&nbsp;#{number_with_delimiter(reservation.total_amount)}
-                                              </div>
-                                            </div>
-                                            よろしければ「削除」ボタンを押してください。",
-                                  commit: "削除",
-                                  cancel: "キャンセル"
-                                }
+                                class: "DropdownMenu__delete-button",
+                                form: { data: { turbo_confirm: "#{reservation.room.name}\n#{reservation.start_date.strftime('%Y/%m/%d')} 〜 #{reservation.end_date.strftime('%Y/%m/%d')}\n#{reservation.person_num}人\n¥ #{number_with_delimiter(reservation.total_amount)}\n\nこの予約を削除しますか？" } }
                     %>
                   </li>
                 </ul>

--- a/app/views/shared/rooms/_form.html.erb
+++ b/app/views/shared/rooms/_form.html.erb
@@ -41,9 +41,10 @@
     <p class=" RoomsForm__input FileUploadArea__input-group">
       <%= f.label :image, "施設画像", class: "FileUploadArea__label" do %>
         <span>画像アップロード</span>
-        <%= f.file_field :image %>
+        <%= f.file_field :image, accept: "image/jpeg,image/png,image/gif" %>
       <% end %>
     </p>
+    <%= render "shared/error_message", object: @room, key: "image" %>
   </div>
 
   <%= f.submit "保存", class: 'btn RoomsForm__button RoomsForm__button--submit' %>

--- a/app/views/users/profile/edit.html.erb
+++ b/app/views/users/profile/edit.html.erb
@@ -20,9 +20,10 @@
 
             <%= f.label :image, "アイコン画像", class: "FileUploadArea__label" do %>
               <span>画像アップロード</span>
-              <%= f.file_field :image %>
+              <%= f.file_field :image, accept: "image/jpeg,image/png,image/gif" %>
             <% end %>
           </p>
+          <%= render "shared/error_message", object: current_user, key: "image" %>
         </div>
 
         <div class="AccountInformation__input-group">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,12 @@
 ja:
   activerecord:
     attributes:
+      user:
+        name: ユーザー名
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: 確認用パスワード
+        image: プロフィール画像
       room:
         name: 施設名
         content: 施設詳細
@@ -13,13 +19,31 @@ ja:
         person_num: 人数
     errors:
       models:
+        user:
+          attributes:
+            name:
+              blank: "を入力してください。"
+            email:
+              blank: "を入力してください。"
+              invalid: "の形式が正しくありません。"
+              taken: "は既に登録されています。"
+            password:
+              blank: "を入力してください。"
+              too_short: "は%{count}文字以上で入力してください。"
+            password_confirmation:
+              confirmation: "がパスワードと一致しません。"
+            image:
+              content_type_invalid: "は画像ファイル（JPEG、PNG、GIF）を選択してください。"
         room:
           attributes:
             name:
               blank: "は必須です。"
+              too_long: "は%{count}文字以内で入力してください。"
             content:
               blank: "は必須です。"
             price:
               blank: "は必須です。"
             address:
               blank: "は必須です。"
+            image:
+              content_type_invalid: "は画像ファイル（JPEG、PNG、GIF）を選択してください。"


### PR DESCRIPTION
## Summary
- 施設詳細画面のカレンダー初期化をTurbo対応に修正
- 再予約画面のフォーム送信が動作しない問題を修正
- 予約削除モーダルのHTMLエスケープ問題を修正
- ユーザー登録時のメールアドレス重複エラーメッセージを追加
- 画像アップロード時のファイル形式バリデーションを追加
- 施設名の文字数制限（255文字）を追加

## 修正内容

### 動作不備
1. **施設詳細画面のカレンダー表示**
   - `turbo:load`イベントでDatePickerを初期化するよう修正
   - 初回アクセス時もカレンダーが表示されるようになった

2. **再予約画面**
   - フォームに`data: { turbo: false }`を追加
   - 「再予約する」ボタンが正常に動作するようになった

3. **予約削除モーダル**
   - `link_to`から`button_to`に変更しTurbo対応
   - HTMLタグがそのまま表示される問題を解消

### 仕様対応
1. **アカウント作成画面のエラーメッセージ**
   - `ja.yml`にUserモデルのエラーメッセージを追加
   - メールアドレス重複時に「メールアドレスは既に登録されています。」と表示

### 要件外の改善
1. **画像アップロードのバリデーション**
   - Room/Userモデルに画像形式チェックを追加（JPEG/PNG/GIFのみ許可）
   - フォームに`accept`属性を追加
   - エラーメッセージを表示

2. **施設名の文字数制限**
   - Roomモデルに`length: { maximum: 255 }`バリデーションを追加
   - DBエラーではなくバリデーションエラーとして処理

## Test plan
- [ ] 施設詳細画面に初回アクセスした際にカレンダーが表示されることを確認
- [ ] 再予約画面で「再予約する」ボタンを押下し、確認画面に遷移することを確認
- [ ] 予約削除モーダルが正常に表示され、削除が実行できることを確認
- [ ] 既存メールアドレスでアカウント作成時にエラーメッセージが表示されることを確認
- [ ] 画像以外のファイルをアップロードした際にエラーメッセージが表示されることを確認
- [ ] 施設名に256文字以上入力した際にバリデーションエラーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)